### PR TITLE
Repair SecureSocketConnector

### DIFF
--- a/src/SMTP/Connector/SecureSocketConnector.php
+++ b/src/SMTP/Connector/SecureSocketConnector.php
@@ -18,7 +18,7 @@ class SecureSocketConnector extends SocketConnector
      */
     public function __construct($host, $port = 25, $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT)
     {
-        parent::__construct($this->host, $port);
+        parent::__construct($host, $port);
 
         $this->crypto_method = $crypto_method;
     }


### PR DESCRIPTION
The `$host` parameter has not been handled correctly, so using this Connector would always fail for lack of a host name.