### PR TITLE
Fix README attachment reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $message = new Message(
     $text                       // plain text message body
 );
 
-$service->addAttachment(Attachment::fromFile(__DIR__ . "/awsum/unicorns.gif"));
+$message->addAttachment(Attachment::fromFile(__DIR__ . "/awsum/unicorns.gif"));
 
 $service->send($message);
 ```


### PR DESCRIPTION
*s/service/message/*

I'm pretty sure the reference to `$service->addAttachment()` is meant to be `$message->addAttachment()`