### PR TITLE
Added missing return type to `SMTPDotStuffingFilter::filter`

### DIFF
--- a/src/SMTP/SMTPDotStuffingFilter.php
+++ b/src/SMTP/SMTPDotStuffingFilter.php
@@ -35,7 +35,7 @@ class SMTPDotStuffingFilter extends Filter
      *
      * @return int
      */
-    public function filter($in, $out, &$consumed, $closing)
+    public function filter($in, $out, &$consumed, $closing): int
     {
         while ($bucket = stream_bucket_make_writeable($in)) {
             $data = substr(


### PR DESCRIPTION
Just triggered this error
```
During inheritance of php_user_filter: Uncaught ErrorException: Return type of Kodus\Mail\SMTP\SMTPDotStuffingFilter::filter($in, $out, &$consumed, $closing) should either be compatible with php_user_filter::filter($in, $out, &$consumed, bool $closing): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/projects/jourbox/vendor/kodus/mail/src/SMTP/SMTPDotStuffingFilter.php:38
```

No idea why the tests aren't failing since this filter is used every time a mail is send :confused: 