### PR TITLE
Add support for psr/log 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">= 8.0",
-        "psr/log": "^1"
+        "psr/log": "^1 || ^2 || ^3"
     },
     "require-dev": {
         "codeception/codeception": "^5",

--- a/tests/Mocks/MockLogger.php
+++ b/tests/Mocks/MockLogger.php
@@ -2,56 +2,17 @@
 
 namespace Kodus\Mail\Test\Mocks;
 
+use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 
-class MockLogger implements LoggerInterface
+class MockLogger extends AbstractLogger implements LoggerInterface
 {
     /**
      * @var string[]
      */
     public $records = [];
 
-    public function emergency($message, array $context = [])
-    {
-        $this->append($message);
-    }
-
-    public function alert($message, array $context = [])
-    {
-        $this->append($message);
-    }
-
-    public function critical($message, array $context = [])
-    {
-        $this->append($message);
-    }
-
-    public function error($message, array $context = [])
-    {
-        $this->append($message);
-    }
-
-    public function warning($message, array $context = [])
-    {
-        $this->append($message);
-    }
-
-    public function notice($message, array $context = [])
-    {
-        $this->append($message);
-    }
-
-    public function info($message, array $context = [])
-    {
-        $this->append($message);
-    }
-
-    public function debug($message, array $context = [])
-    {
-        $this->append($message);
-    }
-
-    public function log($level, $message, array $context = [])
+    public function log($level, mixed $message, array $context = []): void
     {
         $this->append($message);
     }


### PR DESCRIPTION
Make it so I can use this package with never applications.

The only place this package actually implements anything from the log package is in `SMTPClient` and that code is still valid